### PR TITLE
fix PATH_MAX bug on Linux

### DIFF
--- a/src/pc/linux/java/File.cpp
+++ b/src/pc/linux/java/File.cpp
@@ -210,7 +210,7 @@ File *File::openResourceDirectory()
 		length = -1;
 	}
 	#else
-	length = ::readlink("/proc/self/exe", path, sizeof(path) - 1);
+	length = ::readlink("/proc/self/exe", path, PATH_MAX - 1);
 	#endif
 	if (length == -1)
 		return new File_Impl(u"");


### PR DESCRIPTION
`sizeof(path)` incorrectly returns the size of the pointer to the path (about 8 bytes) which causes resources to fail to load